### PR TITLE
Improve responsive layout for monitoring pages

### DIFF
--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -124,14 +124,58 @@
     td.actions{white-space:nowrap}
     .mono{font-family:ui-monospace,Consolas,Menlo,monospace}
 
-    @media (max-width:760px){
-      .col-id{display:none}
-      .btn .txt{display:none}
-      .searchbar{min-width:180px}
-    }
+    .action-buttons{display:flex;gap:8px;justify-content:flex-end;flex-wrap:wrap}
+    .action-buttons > *{margin:0}
+    .action-buttons form{display:inline-flex}
+    .action-buttons .btn{white-space:nowrap}
+
+    .hash-cell{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
+
 
     .hint{font-size:12px;color:var(--muted)}
     .grid-fit{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(min(320px,100%),1fr))}
+    .form-actions{display:flex;gap:10px;flex-wrap:wrap}
+    .form-actions .btn{flex:1 1 auto}
+
+    @media (max-width:960px){
+      .col-id{display:none}
+    }
+    @media (max-width:780px){
+      .nav-actions{width:100%;justify-content:stretch;align-items:stretch;flex-direction:column}
+      .nav-actions .btn{flex:1 1 100%;justify-content:center}
+      .toolbar{width:100%;align-items:stretch}
+      .toolbar form{flex:1 1 100%}
+      .toolbar .searchbar{min-width:0;flex:1 1 100%}
+      .toolbar .btn{flex:1 1 100%;justify-content:center}
+      .action-buttons{justify-content:stretch}
+      .action-buttons > *{flex:1 1 100%}
+      .action-buttons form{width:100%}
+      .action-buttons .btn{width:100%;justify-content:center}
+      .form-actions{flex-direction:column}
+      .form-actions .btn{width:100%}
+    }
+    @media (max-width:720px){
+      .app-header{align-items:flex-start}
+      .card .card-header{align-items:stretch}
+      .searchbar{min-width:0;flex-basis:100%}
+      .table-wrap{overflow:visible;border:none;background:transparent;box-shadow:none;padding:0}
+      table[data-mobile-card]{border-spacing:0}
+      table[data-mobile-card] thead{display:none}
+      table[data-mobile-card] tbody{display:grid;gap:14px;margin:0;padding:0}
+      table[data-mobile-card] tr{display:grid;gap:10px;padding:16px;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);box-shadow:var(--shadow)}
+      table[data-mobile-card] td{display:flex;gap:12px;align-items:flex-start;padding:0;border:none}
+      table[data-mobile-card] td::before{content:attr(data-label);font-weight:700;color:var(--muted);flex:0 0 auto;text-transform:uppercase;font-size:11px;letter-spacing:.08em}
+      table[data-mobile-card] td.actions{flex-direction:column}
+      table[data-mobile-card] td.actions::before{margin-bottom:6px}
+      table[data-mobile-card] td.actions .action-buttons{flex-direction:column;gap:8px}
+      table[data-mobile-card] td.actions .btn{width:100%}
+      table[data-mobile-card] td[colspan]{display:block}
+      table[data-mobile-card] td[colspan]::before{display:none}
+      table[data-mobile-card] .hash-cell{flex-direction:column;align-items:stretch;gap:6px}
+    }
+    @media (max-width:520px){
+      .brand{flex-direction:column;align-items:flex-start}
+    }
   </style>
 
   <script>

--- a/src/main/resources/templates/pages.html
+++ b/src/main/resources/templates/pages.html
@@ -23,7 +23,7 @@
 
     <div class="card-body">
       <div class="table-wrap">
-        <table id="pagesTable">
+        <table id="pagesTable" data-mobile-card="true">
           <thead>
           <tr>
             <th class="col-id">ID</th>
@@ -36,36 +36,38 @@
           </thead>
           <tbody>
           <tr th:each="p : ${pages}" th:attr="data-url=${p.url}">
-            <td class="col-id mono" th:text="${p.id}">1</td>
-            <td>
+            <td class="col-id mono" data-label="ID" th:text="${p.id}">1</td>
+            <td data-label="URL">
               <a th:href="${p.url}" th:text="${p.url}" target="_blank" rel="noopener">https://...</a>
             </td>
-            <td class="mono">
+            <td class="mono" data-label="Último chequeo">
               <time th:text="${p.lastChecked != null ? #temporals.format(p.lastChecked, 'dd/MM/yyyy HH:mm') : '-'}"
                     th:attr="datetime=${p.lastChecked != null ? #temporals.formatISO(p.lastChecked) : ''}">
               </time>
             </td>
-            <td class="mono">
+            <td class="mono" data-label="Última modificación">
               <time th:text="${p.lastChanged != null ? #temporals.format(p.lastChanged, 'dd/MM/yyyy HH:mm') : '-'}"
                     th:attr="datetime=${p.lastChanged != null ? #temporals.formatISO(p.lastChanged) : ''}">
               </time>
             </td>
-            <td>
+            <td data-label="Estado">
               <span th:if="${p.lastError == null}" class="badge badge-ok">OK</span>
               <span th:if="${p.lastError != null}" class="badge badge-err" th:attr="title=${p.lastError}">Error</span>
             </td>
-            <td class="actions" style="text-align:right">
-              <form th:action="@{'/pages/' + ${p.id} + '/check'}" method="post" style="display:inline">
-                <button class="btn" type="submit" title="Chequear ahora">⟳ <span class="txt">Check</span></button>
-              </form>
-              <a class="btn" th:href="@{'/pages/' + ${p.id} + '/versions'}" title="Ver historial">🕘 <span class="txt">Versiones</span></a>
-              <form th:action="@{'/pages/' + ${p.id} + '/delete'}" method="post" style="display:inline"
-                    onsubmit="return confirm('¿Eliminar esta URL del monitoreo?')">
-                <button class="btn btn-danger" type="submit" title="Eliminar">🗑 <span class="txt">Eliminar</span></button>
-              </form>
+            <td class="actions" data-label="Acciones" style="text-align:right">
+              <div class="action-buttons">
+                <form th:action="@{'/pages/' + ${p.id} + '/check'}" method="post">
+                  <button class="btn" type="submit" title="Chequear ahora">⟳ <span class="txt">Check</span></button>
+                </form>
+                <a class="btn" th:href="@{'/pages/' + ${p.id} + '/versions'}" title="Ver historial">🕘 <span class="txt">Versiones</span></a>
+                <form th:action="@{'/pages/' + ${p.id} + '/delete'}" method="post"
+                      onsubmit="return confirm('¿Eliminar esta URL del monitoreo?')">
+                  <button class="btn btn-danger" type="submit" title="Eliminar">🗑 <span class="txt">Eliminar</span></button>
+                </form>
+              </div>
             </td>
           </tr>
-          <tr th:if="${#lists.isEmpty(pages)}">
+          <tr th:if="${#lists.isEmpty(pages)}" class="empty-row">
             <td colspan="6" style="text-align:center;color:var(--muted);padding:18px">
               No hay URLs aún. Hacé clic en <b>Agregar URL</b> para empezar.
             </td>

--- a/src/main/resources/templates/pages_new.html
+++ b/src/main/resources/templates/pages_new.html
@@ -21,7 +21,7 @@
                  style="padding:12px;border:1px solid var(--border);border-radius:12px;background:var(--bg);color:var(--text)"/>
           <small class="hint">Usá una URL canónica de la sección; evitá URLs con parámetros dinámicos.</small>
         </label>
-        <div style="display:flex; gap:10px;">
+        <div class="form-actions">
           <button class="btn btn-primary" type="submit">＋ Guardar</button>
           <a class="btn" href="/pages">← Volver</a>
         </div>

--- a/src/main/resources/templates/pages_versions.html
+++ b/src/main/resources/templates/pages_versions.html
@@ -22,7 +22,7 @@
 
         <div class="card-body">
             <div class="table-wrap">
-                <table id="versionsTable">
+                <table id="versionsTable" data-mobile-card="true">
                     <thead>
                     <tr>
                         <th>Fecha</th>
@@ -32,22 +32,24 @@
                     </thead>
                     <tbody>
                     <tr th:each="v : ${versions}" th:attr="data-hash=${v.hash}">
-                        <td class="mono">
+                        <td class="mono" data-label="Fecha">
                             <time th:text="${#temporals.format(v.createdAt, 'dd/MM/yyyy HH:mm')}"
                                   th:attr="datetime=${#temporals.formatISO(v.createdAt)}"></time>
                         </td>
-                        <td class="mono">
+                        <td class="mono hash-cell" data-label="Hash">
                             <span th:text="${v.hash}">hash</span>
                             <button class="btn btn-ghost" type="button" title="Copiar hash"
                                     onclick="navigator.clipboard.writeText(this.previousElementSibling.textContent)">
                                 📋 <span class="txt">Copiar</span>
                             </button>
                         </td>
-                        <td class="actions" style="text-align:right">
-                            <a class="btn" th:href="@{'/pages/' + ${page.id} + '/diff/' + ${v.id}}">🧩 <span class="txt">Ver diff</span></a>
+                        <td class="actions" data-label="Acciones" style="text-align:right">
+                            <div class="action-buttons">
+                                <a class="btn" th:href="@{'/pages/' + ${page.id} + '/diff/' + ${v.id}}">🧩 <span class="txt">Ver diff</span></a>
+                            </div>
                         </td>
                     </tr>
-                    <tr th:if="${#lists.isEmpty(versions)}">
+                    <tr th:if="${#lists.isEmpty(versions)}" class="empty-row">
                         <td colspan="3" style="text-align:center;color:var(--muted);padding:18px">
                             Aún no hay versiones guardadas para esta página.
                         </td>


### PR DESCRIPTION
## Summary
- enhance shared styles to adapt navigation, toolbars, and tables to small screens with card-like layouts
- update pages, versions, and new page templates to provide mobile metadata labels and stacked action controls

## Testing
- `./mvnw -q test` *(fails: unable to download Maven wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68df3b10216c832eb4f9d68f22407390