### PR TITLE
Add mobile responsive layout for monitoring UI

### DIFF
--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -71,7 +71,12 @@
     }
 
     .toolbar{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
+    .toolbar form{display:inline}
     .spacer{flex:1 1 auto}
+
+    .form-stack{display:grid;gap:14px;max-width:780px}
+    .form-field{display:grid;gap:8px}
+    .form-actions{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
 
     .btn{
       appearance:none;border:1px solid var(--border);background:var(--card);color:var(--text);
@@ -122,6 +127,7 @@
     tbody tr:hover{background:rgba(0,0,0,.02)}
     @media (prefers-color-scheme: dark){ tbody tr:hover{background:rgba(255,255,255,.03)} }
     td.actions{white-space:nowrap}
+    td.actions form{display:inline}
     .mono{font-family:ui-monospace,Consolas,Menlo,monospace}
 
     @media (max-width:760px){
@@ -132,6 +138,43 @@
 
     .hint{font-size:12px;color:var(--muted)}
     .grid-fit{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(min(320px,100%),1fr))}
+
+    @media (max-width:720px){
+      body{background:var(--bg);}
+      .container{max-width:100%;padding-inline:20px;padding-block:20px}
+      .app-header{flex-direction:column;align-items:stretch;margin-bottom:12px}
+      .brand{justify-content:space-between}
+      .nav-actions{width:100%;display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:8px}
+      .nav-actions .btn{justify-content:center;width:100%}
+      .card{border-radius:20px}
+      .card .card-header{flex-direction:column;align-items:stretch;gap:14px;padding:18px}
+      .card .card-body{padding:20px 18px}
+      .toolbar{flex-direction:column;align-items:stretch}
+      .toolbar .btn{width:100%;justify-content:center}
+      .toolbar form{display:block !important;width:100%}
+      .toolbar form .btn{width:100%}
+      .toolbar .searchbar{width:100%;min-width:0}
+      .searchbar input{padding-block:14px}
+      .btn{font-size:15px}
+      .btn .txt{display:inline}
+      .form-actions{flex-direction:column;align-items:stretch}
+      .form-actions .btn{width:100%;justify-content:center}
+      .table-wrap{border:none;background:transparent;box-shadow:none;padding:0}
+      .table-wrap table{display:block;border-spacing:0;background:transparent}
+      .stack-table tbody{display:grid;gap:12px;margin:0;padding:0}
+      .stack-table tbody tr[data-stack-row]{display:grid;gap:12px;padding:18px;border:1px solid var(--border);border-radius:18px;background:var(--card);box-shadow:var(--shadow)}
+      .stack-table tbody tr[data-stack-row] td{display:flex;flex-direction:column;align-items:flex-start;gap:6px;border:none;padding:0}
+      .stack-table tbody tr[data-stack-row] td::before{content:attr(data-label);font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}
+      .stack-table tbody tr[data-stack-row] td .btn{width:100%;justify-content:center}
+      .stack-table tbody tr[data-stack-row] td.actions{gap:10px;align-items:stretch}
+      .stack-table tbody tr[data-stack-row] td.actions::before{margin-bottom:4px}
+      .stack-table tbody tr[data-stack-row] td.actions{width:100%}
+      .stack-table tbody tr[data-stack-row] td.actions form{display:block !important;width:100%}
+      .stack-table tbody tr[data-stack-row] td.actions form .btn{width:100%}
+      .stack-table tbody tr[data-stack-row] td.actions a{width:100%}
+      .stack-table thead{display:none}
+      .badge{font-size:13px}
+    }
   </style>
 
   <script>

--- a/src/main/resources/templates/pages.html
+++ b/src/main/resources/templates/pages.html
@@ -14,7 +14,7 @@
       <div class="toolbar">
         <div class="searchbar">
           <span class="icon">🔎</span>
-          <input id="q" type="search" placeholder="Filtrar por URL..." aria-label="Buscar por URL"/>
+          <input id="pages-filter" type="search" placeholder="Filtrar por URL..." aria-label="Buscar por URL"/>
         </div>
         <a class="btn" href="/pages" title="Refrescar lista">⟲ <span class="txt">Refrescar</span></a>
         <a class="btn btn-primary" href="/pages/new">＋ <span class="txt">Agregar URL</span></a>
@@ -23,7 +23,7 @@
 
     <div class="card-body">
       <div class="table-wrap">
-        <table id="pagesTable" class="stack-table">
+        <table id="pages-table" class="stack-table">
           <thead>
           <tr>
             <th class="col-id">ID</th>
@@ -35,7 +35,7 @@
           </tr>
           </thead>
           <tbody>
-          <tr th:each="p : ${pages}" th:attr="data-url=${p.url},data-stack-row=${true}">
+          <tr th:each="p : ${pages}" data-stack-row="true" th:attr="data-url=${p.url}">
             <td class="col-id mono" data-label="ID" th:text="${p.id}">1</td>
             <td data-label="URL">
               <a th:href="${p.url}" th:text="${p.url}" target="_blank" rel="noopener">https://...</a>
@@ -83,8 +83,8 @@
 
 <script>
   (function(){
-    const q = document.getElementById('q');
-    const rows = Array.from(document.querySelectorAll('#pagesTable tbody tr'))
+    const q = document.getElementById('pages-filter');
+    const rows = Array.from(document.querySelectorAll('#pages-table tbody tr'))
                        .filter(tr => tr.hasAttribute('data-url'));
     function apply(){
       const term = (q.value || '').toLowerCase().trim();

--- a/src/main/resources/templates/pages.html
+++ b/src/main/resources/templates/pages.html
@@ -23,7 +23,7 @@
 
     <div class="card-body">
       <div class="table-wrap">
-        <table id="pagesTable">
+        <table id="pagesTable" class="stack-table">
           <thead>
           <tr>
             <th class="col-id">ID</th>
@@ -35,31 +35,31 @@
           </tr>
           </thead>
           <tbody>
-          <tr th:each="p : ${pages}" th:attr="data-url=${p.url}">
-            <td class="col-id mono" th:text="${p.id}">1</td>
-            <td>
+          <tr th:each="p : ${pages}" th:attr="data-url=${p.url},data-stack-row=${true}">
+            <td class="col-id mono" data-label="ID" th:text="${p.id}">1</td>
+            <td data-label="URL">
               <a th:href="${p.url}" th:text="${p.url}" target="_blank" rel="noopener">https://...</a>
             </td>
-            <td class="mono">
+            <td class="mono" data-label="Último chequeo">
               <time th:text="${p.lastChecked != null ? #temporals.format(p.lastChecked, 'dd/MM/yyyy HH:mm') : '-'}"
                     th:attr="datetime=${p.lastChecked != null ? #temporals.formatISO(p.lastChecked) : ''}">
               </time>
             </td>
-            <td class="mono">
+            <td class="mono" data-label="Última modificación">
               <time th:text="${p.lastChanged != null ? #temporals.format(p.lastChanged, 'dd/MM/yyyy HH:mm') : '-'}"
                     th:attr="datetime=${p.lastChanged != null ? #temporals.formatISO(p.lastChanged) : ''}">
               </time>
             </td>
-            <td>
+            <td data-label="Estado">
               <span th:if="${p.lastError == null}" class="badge badge-ok">OK</span>
               <span th:if="${p.lastError != null}" class="badge badge-err" th:attr="title=${p.lastError}">Error</span>
             </td>
-            <td class="actions" style="text-align:right">
-              <form th:action="@{'/pages/' + ${p.id} + '/check'}" method="post" style="display:inline">
+            <td class="actions" data-label="Acciones" style="text-align:right">
+              <form th:action="@{'/pages/' + ${p.id} + '/check'}" method="post">
                 <button class="btn" type="submit" title="Chequear ahora">⟳ <span class="txt">Check</span></button>
               </form>
               <a class="btn" th:href="@{'/pages/' + ${p.id} + '/versions'}" title="Ver historial">🕘 <span class="txt">Versiones</span></a>
-              <form th:action="@{'/pages/' + ${p.id} + '/delete'}" method="post" style="display:inline"
+              <form th:action="@{'/pages/' + ${p.id} + '/delete'}" method="post"
                     onsubmit="return confirm('¿Eliminar esta URL del monitoreo?')">
                 <button class="btn btn-danger" type="submit" title="Eliminar">🗑 <span class="txt">Eliminar</span></button>
               </form>

--- a/src/main/resources/templates/pages_new.html
+++ b/src/main/resources/templates/pages_new.html
@@ -14,14 +14,14 @@
     </div>
 
     <div class="card-body">
-      <form action="/pages" method="post" style="display:grid; gap:14px; max-width:780px;">
-        <label style="display:grid; gap:8px;">
+      <form action="/pages" method="post" class="form-stack">
+        <label class="form-field">
           <span>URL a monitorear</span>
           <input type="url" name="url" required placeholder="https://www.clarin.com/politica"
                  style="padding:12px;border:1px solid var(--border);border-radius:12px;background:var(--bg);color:var(--text)"/>
           <small class="hint">Usá una URL canónica de la sección; evitá URLs con parámetros dinámicos.</small>
         </label>
-        <div style="display:flex; gap:10px;">
+        <div class="form-actions">
           <button class="btn btn-primary" type="submit">＋ Guardar</button>
           <a class="btn" href="/pages">← Volver</a>
         </div>

--- a/src/main/resources/templates/pages_versions.html
+++ b/src/main/resources/templates/pages_versions.html
@@ -22,7 +22,7 @@
 
         <div class="card-body">
             <div class="table-wrap">
-                <table id="versionsTable">
+                <table id="versionsTable" class="stack-table">
                     <thead>
                     <tr>
                         <th>Fecha</th>
@@ -31,19 +31,19 @@
                     </tr>
                     </thead>
                     <tbody>
-                    <tr th:each="v : ${versions}" th:attr="data-hash=${v.hash}">
-                        <td class="mono">
+                    <tr th:each="v : ${versions}" th:attr="data-hash=${v.hash},data-stack-row=${true}">
+                        <td class="mono" data-label="Fecha">
                             <time th:text="${#temporals.format(v.createdAt, 'dd/MM/yyyy HH:mm')}"
                                   th:attr="datetime=${#temporals.formatISO(v.createdAt)}"></time>
                         </td>
-                        <td class="mono">
+                        <td class="mono" data-label="Hash">
                             <span th:text="${v.hash}">hash</span>
                             <button class="btn btn-ghost" type="button" title="Copiar hash"
                                     onclick="navigator.clipboard.writeText(this.previousElementSibling.textContent)">
                                 📋 <span class="txt">Copiar</span>
                             </button>
                         </td>
-                        <td class="actions" style="text-align:right">
+                        <td class="actions" data-label="Acciones" style="text-align:right">
                             <a class="btn" th:href="@{'/pages/' + ${page.id} + '/diff/' + ${v.id}}">🧩 <span class="txt">Ver diff</span></a>
                         </td>
                     </tr>

--- a/src/main/resources/templates/pages_versions.html
+++ b/src/main/resources/templates/pages_versions.html
@@ -14,7 +14,7 @@
             <div class="toolbar">
                 <div class="searchbar">
                     <span class="icon">🔎</span>
-                    <input id="q" type="search" placeholder="Filtrar por hash..." aria-label="Buscar por hash"/>
+                    <input id="versions-filter" type="search" placeholder="Filtrar por hash..." aria-label="Buscar por hash"/>
                 </div>
                 <a class="btn" th:href="@{'/pages'}">← Páginas</a>
             </div>
@@ -22,7 +22,7 @@
 
         <div class="card-body">
             <div class="table-wrap">
-                <table id="versionsTable" class="stack-table">
+                <table id="versions-table" class="stack-table">
                     <thead>
                     <tr>
                         <th>Fecha</th>
@@ -31,7 +31,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    <tr th:each="v : ${versions}" th:attr="data-hash=${v.hash},data-stack-row=${true}">
+                    <tr th:each="v : ${versions}" data-stack-row="true" th:attr="data-hash=${v.hash}">
                         <td class="mono" data-label="Fecha">
                             <time th:text="${#temporals.format(v.createdAt, 'dd/MM/yyyy HH:mm')}"
                                   th:attr="datetime=${#temporals.formatISO(v.createdAt)}"></time>
@@ -64,8 +64,8 @@
 
 <script>
     (function(){
-      const q = document.getElementById('q');
-      const rows = Array.from(document.querySelectorAll('#versionsTable tbody tr'))
+      const q = document.getElementById('versions-filter');
+      const rows = Array.from(document.querySelectorAll('#versions-table tbody tr'))
         .filter(tr => tr.hasAttribute('data-hash'));
       function apply(){
         const term = (q.value || '').toLowerCase().trim();

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -13,7 +13,7 @@
             </div>
             <div class="toolbar">
                 <a class="btn" href="/pages">← Páginas</a>
-                <form action="/settings/test-email" method="post" style="display:inline">
+                <form action="/settings/test-email" method="post">
                     <button class="btn btn-primary" type="submit">✉ Enviar email de prueba</button>
                 </form>
             </div>


### PR DESCRIPTION
## Summary
- add responsive utility classes and mobile media queries to the shared fragment styles
- convert monitoring tables into card-based stacks on narrow screens while keeping desktop layout intact
- update page templates to provide data labels and responsive form layout support

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df3eecf158832ebea8ba22f08640b4