### PR TITLE
Improve mobile responsiveness for UI templates

### DIFF
--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -72,6 +72,15 @@
 
     .toolbar{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
     .spacer{flex:1 1 auto}
+    .toolbar-form{display:inline-flex;gap:0;align-items:stretch}
+    .form-grid{display:grid;gap:14px;max-width:780px}
+    .form-field{display:grid;gap:8px}
+    .input-control{
+      padding:12px;border:1px solid var(--border);border-radius:12px;background:var(--bg);color:var(--text);
+    }
+    .form-actions{display:flex;gap:10px;align-items:center}
+    .card-ghost{border:none;box-shadow:none;background:transparent}
+    .settings-grid{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(240px,1fr))}
 
     .btn{
       appearance:none;border:1px solid var(--border);background:var(--card);color:var(--text);
@@ -132,6 +141,29 @@
 
     .hint{font-size:12px;color:var(--muted)}
     .grid-fit{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(min(320px,100%),1fr))}
+
+    @media (max-width:520px){
+      body{font-size:15px}
+      .container{padding-inline:20px;padding-block:20px}
+      .app-header{flex-direction:column;align-items:flex-start}
+      .brand{width:100%;justify-content:space-between}
+      .nav-actions{width:100%;display:grid;grid-template-columns:1fr;gap:8px}
+      .nav-actions .btn{width:100%;justify-content:center}
+      .card .card-header{flex-direction:column;align-items:flex-start}
+      .toolbar{flex-direction:column;align-items:stretch;width:100%}
+      .toolbar .btn,.toolbar a.btn{width:100%;justify-content:center}
+      .toolbar-form{width:100%;display:flex}
+      .toolbar-form .btn{width:100%;justify-content:center}
+      .toolbar .searchbar{min-width:0;width:100%}
+      .searchbar input{padding:12px 12px 12px 40px;font-size:16px}
+      .table-wrap{border-radius:var(--radius);overflow-x:auto;-webkit-overflow-scrolling:touch}
+      table{min-width:600px}
+      .form-grid{max-width:100%}
+      .form-actions{flex-direction:column;align-items:stretch}
+      .form-actions .btn,.form-actions a.btn{width:100%;justify-content:center}
+      .settings-grid{grid-template-columns:1fr}
+      .hint{font-size:13px}
+    }
   </style>
 
   <script>

--- a/src/main/resources/templates/pages.html
+++ b/src/main/resources/templates/pages.html
@@ -4,25 +4,25 @@
 <body>
 <div th:replace="~{fragments :: navbar}"></div>
 
-<main class="container">
-  <section class="card">
-    <div class="card-header">
-      <div>
+<main class="container"><!-- main-container-open -->
+  <section class="card"><!-- section-card-open -->
+    <div class="card-header"><!-- card-header-open -->
+      <div><!-- header-intro-open -->
         <h2 style="margin:0 0 6px 0;">Monitoreo de páginas</h2>
         <div class="hint">CRUD de URLs + estado, con acciones rápidas y búsqueda client-side.</div>
-      </div>
-      <div class="toolbar">
-        <div class="searchbar">
+      </div><!-- header-intro-close -->
+      <div class="toolbar"><!-- toolbar-open -->
+        <div class="searchbar"><!-- searchbar-open -->
           <span class="icon">🔎</span>
           <input id="q" type="search" placeholder="Filtrar por URL..." aria-label="Buscar por URL"/>
-        </div>
-        <a class="btn" href="/pages" title="Refrescar lista">⟲ <span class="txt">Refrescar</span></a>
-        <a class="btn btn-primary" href="/pages/new">＋ <span class="txt">Agregar URL</span></a>
-      </div>
-    </div>
+        </div><!-- searchbar-close -->
+        <a class="btn" href="/pages" title="Refrescar lista"><!-- refresh-link-open -->⟲ <span class="txt">Refrescar</span></a><!-- refresh-link-close -->
+        <a class="btn btn-primary" href="/pages/new"><!-- add-link-open -->＋ <span class="txt">Agregar URL</span></a><!-- add-link-close -->
+      </div><!-- toolbar-close -->
+    </div><!-- card-header-close -->
 
-    <div class="card-body">
-      <div class="table-wrap">
+    <div class="card-body"><!-- card-body-open -->
+      <div class="table-wrap"><!-- table-wrap-open -->
         <table id="pagesTable">
           <thead>
           <tr>
@@ -38,7 +38,7 @@
           <tr th:each="p : ${pages}" th:attr="data-url=${p.url}">
             <td class="col-id mono" th:text="${p.id}">1</td>
             <td>
-              <a th:href="${p.url}" th:text="${p.url}" target="_blank" rel="noopener">https://...</a>
+              <a th:href="${p.url}" th:text="${p.url}" target="_blank" rel="noopener"><!-- url-link-open -->https://...</a><!-- url-link-close -->
             </td>
             <td class="mono">
               <time th:text="${p.lastChecked != null ? #temporals.format(p.lastChecked, 'dd/MM/yyyy HH:mm') : '-'}"
@@ -54,16 +54,16 @@
               <span th:if="${p.lastError == null}" class="badge badge-ok">OK</span>
               <span th:if="${p.lastError != null}" class="badge badge-err" th:attr="title=${p.lastError}">Error</span>
             </td>
-            <td class="actions" style="text-align:right">
-              <form th:action="@{'/pages/' + ${p.id} + '/check'}" method="post" style="display:inline">
-                <button class="btn" type="submit" title="Chequear ahora">⟳ <span class="txt">Check</span></button>
-              </form>
-              <a class="btn" th:href="@{'/pages/' + ${p.id} + '/versions'}" title="Ver historial">🕘 <span class="txt">Versiones</span></a>
-              <form th:action="@{'/pages/' + ${p.id} + '/delete'}" method="post" style="display:inline"
-                    onsubmit="return confirm('¿Eliminar esta URL del monitoreo?')">
-                <button class="btn btn-danger" type="submit" title="Eliminar">🗑 <span class="txt">Eliminar</span></button>
-              </form>
-            </td>
+            <td class="actions" style="text-align:right"><!-- actions-cell-open -->
+              <form class="toolbar-form" th:action="@{'/pages/' + ${p.id} + '/check'}" method="post"><!-- form-check-open -->
+                <button class="btn" type="submit" title="Chequear ahora"><!-- check-btn-open -->⟳ <span class="txt">Check</span></button><!-- check-btn-close -->
+              </form><!-- form-check-close -->
+              <a class="btn" th:href="@{'/pages/' + ${p.id} + '/versions'}" title="Ver historial"><!-- versions-link-open -->🕘 <span class="txt">Versiones</span></a><!-- versions-link-close -->
+              <form class="toolbar-form" th:action="@{'/pages/' + ${p.id} + '/delete'}" method="post"
+                    onsubmit="return confirm('¿Eliminar esta URL del monitoreo?')"><!-- form-delete-open -->
+                <button class="btn btn-danger" type="submit" title="Eliminar"><!-- delete-btn-open -->🗑 <span class="txt">Eliminar</span></button><!-- delete-btn-close -->
+              </form><!-- form-delete-close -->
+            </td><!-- actions-cell-close -->
           </tr>
           <tr th:if="${#lists.isEmpty(pages)}">
             <td colspan="6" style="text-align:center;color:var(--muted);padding:18px">
@@ -72,14 +72,14 @@
           </tr>
           </tbody>
         </table>
-      </div>
+      </div><!-- table-wrap-close -->
 
-      <div style="margin-top:10px" class="hint">
+      <div style="margin-top:10px" class="hint"><!-- hint-open -->
         Consejo: pasá el mouse por “Error” para ver el detalle (tooltip).
-      </div>
-    </div>
-  </section>
-</main>
+      </div><!-- hint-close -->
+    </div><!-- card-body-close -->
+  </section><!-- section-card-close -->
+</main><!-- main-container-close -->
 
 <script>
   (function(){

--- a/src/main/resources/templates/pages_diff.html
+++ b/src/main/resources/templates/pages_diff.html
@@ -4,55 +4,55 @@
 <body>
 <div th:replace="~{fragments :: navbar}"></div>
 
-<main class="container">
-  <section class="card">
-    <div class="card-header">
-      <div>
+<main class="container"><!-- main-container-open -->
+  <section class="card"><!-- section-card-open -->
+    <div class="card-header"><!-- card-header-open -->
+      <div><!-- header-intro-open -->
         <h2 style="margin:0 0 6px 0;">Comparar contenido</h2>
-        <div class="hint">
-          Página: <a th:href="${page.url}" target="_blank" rel="noopener" th:text="${page.url}">URL</a>
-        </div>
-      </div>
-      <div class="toolbar">
-        <a class="btn" th:href="@{'/pages/' + ${page.id} + '/versions'}">← Volver a versiones</a>
-        <div class="spacer"></div>
-        <button class="btn" type="button" id="wrapBtn" title="Alternar ajuste de líneas">↔ Ajuste líneas</button>
-        <button class="btn" type="button" id="syncBtn" title="Alternar scroll sincronizado">🔗 Sync scroll</button>
-      </div>
-    </div>
+        <div class="hint"><!-- header-hint-open -->
+          Página: <a th:href="${page.url}" target="_blank" rel="noopener" th:text="${page.url}"><!-- page-link-open -->URL</a><!-- page-link-close -->
+        </div><!-- header-hint-close -->
+      </div><!-- header-intro-close -->
+      <div class="toolbar"><!-- toolbar-open -->
+        <a class="btn" th:href="@{'/pages/' + ${page.id} + '/versions'}"><!-- back-link-open -->← Volver a versiones</a><!-- back-link-close -->
+        <div class="spacer"><!-- spacer-open --></div><!-- spacer-close -->
+        <button class="btn" type="button" id="wrapBtn" title="Alternar ajuste de líneas"><!-- wrap-btn-open -->↔ Ajuste líneas</button><!-- wrap-btn-close -->
+        <button class="btn" type="button" id="syncBtn" title="Alternar scroll sincronizado"><!-- sync-btn-open -->🔗 Sync scroll</button><!-- sync-btn-close -->
+      </div><!-- toolbar-close -->
+    </div><!-- card-header-close -->
 
-    <div class="card-body diff-root wrap">
-      <div class="diff-grid">
-        <div class="diff-col">
-          <div class="diff-header">
+    <div class="card-body diff-root wrap"><!-- card-body-open -->
+      <div class="diff-grid"><!-- diff-grid-open -->
+        <div class="diff-col"><!-- diff-col-left-open -->
+          <div class="diff-header"><!-- diff-header-left-open -->
             <b>Versión seleccionada</b>
-            <span class="badge badge-warn">
+            <span class="badge badge-warn"><!-- badge-left-open -->
                 <span class="mono"
                       th:text="${#temporals.format(version.createdAt, 'dd/MM/yyyy HH:mm')}">fecha</span>
-              </span>
-          </div>
-          <div class="diff-pre-wrap">
+              </span><!-- badge-left-close -->
+          </div><!-- diff-header-left-close -->
+          <div class="diff-pre-wrap"><!-- diff-pre-wrap-left-open -->
             <pre id="preLeft" class="mono diff-pre" th:text="${versionContent}"></pre>
-          </div>
-        </div>
+          </div><!-- diff-pre-wrap-left-close -->
+        </div><!-- diff-col-left-close -->
 
-        <div class="diff-col">
-          <div class="diff-header">
+        <div class="diff-col"><!-- diff-col-right-open -->
+          <div class="diff-header"><!-- diff-header-right-open -->
             <b>Versión actual</b>
-            <span class="badge badge-ok">Actual</span>
-          </div>
-          <div class="diff-pre-wrap">
+            <span class="badge badge-ok"><!-- badge-right-open -->Actual</span><!-- badge-right-close -->
+          </div><!-- diff-header-right-close -->
+          <div class="diff-pre-wrap"><!-- diff-pre-wrap-right-open -->
             <pre id="preRight" class="mono diff-pre" th:text="${currentContent}"></pre>
-          </div>
-        </div>
-      </div>
+          </div><!-- diff-pre-wrap-right-close -->
+        </div><!-- diff-col-right-close -->
+      </div><!-- diff-grid-close -->
 
-      <div class="hint" style="margin-top:12px">
+      <div class="hint" style="margin-top:12px"><!-- hint-open -->
         Tip: Usá <b>↔ Ajuste líneas</b> para alternar entre envoltura (sin overflow) y texto sin envolver (con scroll horizontal interno).
-      </div>
-    </div>
-  </section>
-</main>
+      </div><!-- hint-close -->
+    </div><!-- card-body-close -->
+  </section><!-- section-card-close -->
+</main><!-- main-container-close -->
 
 <style>
   .diff-root{ overflow-x: hidden; }
@@ -96,6 +96,12 @@
   }
   @media (max-width: 900px){
     .diff-grid{ grid-template-columns: 1fr; }
+  }
+  @media (max-width: 520px){
+    .card-header .spacer{display:none}
+    .diff-header{flex-direction:column;align-items:flex-start;gap:6px}
+    .diff-pre{max-height:60vh}
+    .card-body.diff-root{padding-inline:12px}
   }
 </style>
 

--- a/src/main/resources/templates/pages_new.html
+++ b/src/main/resources/templates/pages_new.html
@@ -4,30 +4,29 @@
 <body>
 <div th:replace="~{fragments :: navbar}"></div>
 
-<main class="container">
-  <section class="card">
-    <div class="card-header">
-      <div>
+<main class="container"><!-- main-container-open -->
+  <section class="card"><!-- section-card-open -->
+    <div class="card-header"><!-- card-header-open -->
+      <div><!-- header-intro-open -->
         <h2 style="margin:0 0 6px 0;">Agregar URL</h2>
         <div class="hint">Añadí una página para monitorear cambios de contenido.</div>
-      </div>
-    </div>
+      </div><!-- header-intro-close -->
+    </div><!-- card-header-close -->
 
-    <div class="card-body">
-      <form action="/pages" method="post" style="display:grid; gap:14px; max-width:780px;">
-        <label style="display:grid; gap:8px;">
+    <div class="card-body"><!-- card-body-open -->
+      <form action="/pages" method="post" class="form-grid"><!-- form-open -->
+        <label class="form-field"><!-- field-url-open -->
           <span>URL a monitorear</span>
-          <input type="url" name="url" required placeholder="https://www.clarin.com/politica"
-                 style="padding:12px;border:1px solid var(--border);border-radius:12px;background:var(--bg);color:var(--text)"/>
+          <input class="input-control" type="url" name="url" required placeholder="https://www.clarin.com/politica"/>
           <small class="hint">Usá una URL canónica de la sección; evitá URLs con parámetros dinámicos.</small>
-        </label>
-        <div style="display:flex; gap:10px;">
-          <button class="btn btn-primary" type="submit">＋ Guardar</button>
-          <a class="btn" href="/pages">← Volver</a>
-        </div>
-      </form>
-    </div>
-  </section>
-</main>
+        </label><!-- field-url-close -->
+        <div class="form-actions"><!-- form-actions-open -->
+          <button class="btn btn-primary" type="submit"><!-- submit-btn-open -->＋ Guardar</button><!-- submit-btn-close -->
+          <a class="btn" href="/pages"><!-- back-link-open -->← Volver</a><!-- back-link-close -->
+        </div><!-- form-actions-close -->
+      </form><!-- form-close -->
+    </div><!-- card-body-close -->
+  </section><!-- section-card-close -->
+</main><!-- main-container-close -->
 </body>
 </html>

--- a/src/main/resources/templates/pages_versions.html
+++ b/src/main/resources/templates/pages_versions.html
@@ -4,24 +4,24 @@
 <body>
 <div th:replace="~{fragments :: navbar}"></div>
 
-<main class="container">
-    <section class="card">
-        <div class="card-header">
-            <div>
+<main class="container"><!-- main-container-open -->
+    <section class="card"><!-- section-card-open -->
+        <div class="card-header"><!-- card-header-open -->
+            <div><!-- header-intro-open -->
                 <h2 style="margin:0 0 6px 0;">Versiones</h2>
-                <div class="hint">Historial de capturas para: <a th:href="${page.url}" target="_blank" rel="noopener" th:text="${page.url}">URL</a></div>
-            </div>
-            <div class="toolbar">
-                <div class="searchbar">
+                <div class="hint">Historial de capturas para: <a th:href="${page.url}" target="_blank" rel="noopener" th:text="${page.url}"><!-- page-link-open -->URL</a><!-- page-link-close --></div>
+            </div><!-- header-intro-close -->
+            <div class="toolbar"><!-- toolbar-open -->
+                <div class="searchbar"><!-- searchbar-open -->
                     <span class="icon">🔎</span>
                     <input id="q" type="search" placeholder="Filtrar por hash..." aria-label="Buscar por hash"/>
-                </div>
-                <a class="btn" th:href="@{'/pages'}">← Páginas</a>
-            </div>
-        </div>
+                </div><!-- searchbar-close -->
+                <a class="btn" th:href="@{'/pages'}"><!-- back-link-open -->← Páginas</a><!-- back-link-close -->
+            </div><!-- toolbar-close -->
+        </div><!-- card-header-close -->
 
-        <div class="card-body">
-            <div class="table-wrap">
+        <div class="card-body"><!-- card-body-open -->
+            <div class="table-wrap"><!-- table-wrap-open -->
                 <table id="versionsTable">
                     <thead>
                     <tr>
@@ -39,13 +39,13 @@
                         <td class="mono">
                             <span th:text="${v.hash}">hash</span>
                             <button class="btn btn-ghost" type="button" title="Copiar hash"
-                                    onclick="navigator.clipboard.writeText(this.previousElementSibling.textContent)">
+                                    onclick="navigator.clipboard.writeText(this.previousElementSibling.textContent)"><!-- copy-btn-open -->
                                 📋 <span class="txt">Copiar</span>
-                            </button>
+                            </button><!-- copy-btn-close -->
                         </td>
-                        <td class="actions" style="text-align:right">
-                            <a class="btn" th:href="@{'/pages/' + ${page.id} + '/diff/' + ${v.id}}">🧩 <span class="txt">Ver diff</span></a>
-                        </td>
+                        <td class="actions" style="text-align:right"><!-- actions-cell-open -->
+                            <a class="btn" th:href="@{'/pages/' + ${page.id} + '/diff/' + ${v.id}}"><!-- diff-link-open -->🧩 <span class="txt">Ver diff</span></a><!-- diff-link-close -->
+                        </td><!-- actions-cell-close -->
                     </tr>
                     <tr th:if="${#lists.isEmpty(versions)}">
                         <td colspan="3" style="text-align:center;color:var(--muted);padding:18px">
@@ -54,13 +54,13 @@
                     </tr>
                     </tbody>
                 </table>
-            </div>
-            <div style="margin-top:10px" class="hint">
+            </div><!-- table-wrap-close -->
+            <div style="margin-top:10px" class="hint"><!-- hint-open -->
                 Tip: copiá un hash para comparaciones externas.
-            </div>
-        </div>
-    </section>
-</main>
+            </div><!-- hint-close -->
+        </div><!-- card-body-close -->
+    </section><!-- section-card-close -->
+</main><!-- main-container-close -->
 
 <script>
     (function(){

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -4,42 +4,42 @@
 <body>
 <div th:replace="~{fragments :: navbar}"></div>
 
-<main class="container">
-    <section class="card">
-        <div class="card-header">
-            <div>
+<main class="container"><!-- main-container-open -->
+    <section class="card"><!-- section-card-open -->
+        <div class="card-header"><!-- card-header-open -->
+            <div><!-- header-intro-open -->
                 <h2 style="margin:0 0 6px 0;">Settings</h2>
                 <div class="hint">Valores de configuración activos (perfil local).</div>
-            </div>
-            <div class="toolbar">
-                <a class="btn" href="/pages">← Páginas</a>
-                <form action="/settings/test-email" method="post" style="display:inline">
-                    <button class="btn btn-primary" type="submit">✉ Enviar email de prueba</button>
-                </form>
-            </div>
-        </div>
+            </div><!-- header-intro-close -->
+            <div class="toolbar"><!-- toolbar-open -->
+                <a class="btn" href="/pages"><!-- back-link-open -->← Páginas</a><!-- back-link-close -->
+                <form class="toolbar-form" action="/settings/test-email" method="post"><!-- form-test-email-open -->
+                    <button class="btn btn-primary" type="submit"><!-- test-email-btn-open -->✉ Enviar email de prueba</button><!-- test-email-btn-close -->
+                </form><!-- form-test-email-close -->
+            </div><!-- toolbar-close -->
+        </div><!-- card-header-close -->
 
-        <div class="card-body">
-            <div style="display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(240px,1fr))">
-                <div class="card" style="border:none;box-shadow:none">
+        <div class="card-body"><!-- card-body-open -->
+            <div class="settings-grid"><!-- settings-grid-open -->
+                <div class="card card-ghost"><!-- card-mail-open -->
                     <div class="hint" style="margin-bottom:6px">Correo</div>
                     <div><b>FROM:</b> <span th:text="${props.mailFrom}">from</span></div>
                     <div><b>TO:</b> <span th:text="${props.mailTo}">to</span></div>
-                </div>
+                </div><!-- card-mail-close -->
 
-                <div class="card" style="border:none;box-shadow:none">
+                <div class="card card-ghost"><!-- card-monitor-open -->
                     <div class="hint" style="margin-bottom:6px">Monitor</div>
                     <div><b>User-Agent:</b> <span th:text="${props.userAgent}">UA</span></div>
                     <div><b>Intervalo (min):</b> <span th:text="${props.intervalMinutes}">15</span></div>
                     <div><b>Jitter (ms):</b> <span th:text="${props.jitterMsMax}">30000</span></div>
-                </div>
-            </div>
+                </div><!-- card-monitor-close -->
+            </div><!-- settings-grid-close -->
 
-            <div class="hint" style="margin-top:14px">
+            <div class="hint" style="margin-top:14px"><!-- hint-open -->
                 Los cambios de configuración se aplican reiniciando la app o ajustando variables antes de iniciar.
-            </div>
-        </div>
-    </section>
-</main>
+            </div><!-- hint-close -->
+        </div><!-- card-body-close -->
+    </section><!-- section-card-close -->
+</main><!-- main-container-close -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend the shared stylesheet with responsive utility classes and mobile layout tuning aimed at phone-sized viewports
- update the pages, diff, versions, new page, and settings templates to use the new classes while preserving the desktop view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfda38c23c832eb80a30e6194fb4bb