### PR TITLE
Detect new article link in notifications

### DIFF
--- a/src/main/java/scrapping/noti_radar/model/MonitoredPage.java
+++ b/src/main/java/scrapping/noti_radar/model/MonitoredPage.java
@@ -22,6 +22,10 @@ public class MonitoredPage {
     @Column(length=1024)
     private String lastError;
 
+    @Lob
+    @Column(columnDefinition = "CLOB")
+    private String lastLinks;
+
     public MonitoredPage() {}
     public MonitoredPage(String url) { this.url = url; }
 
@@ -79,6 +83,14 @@ public class MonitoredPage {
 
     public void setLastError(String lastError) {
         this.lastError = lastError;
+    }
+
+    public String getLastLinks() {
+        return lastLinks;
+    }
+
+    public void setLastLinks(String lastLinks) {
+        this.lastLinks = lastLinks;
     }
 
     // getters/setters...

--- a/src/main/java/scrapping/noti_radar/service/NormalizeService.java
+++ b/src/main/java/scrapping/noti_radar/service/NormalizeService.java
@@ -4,6 +4,11 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 @Service
 public class NormalizeService {
 
@@ -18,6 +23,25 @@ public class NormalizeService {
         // normalizar espacios
         text = text.replaceAll("\\s+", " ").trim();
         return text;
+    }
+
+    public List<String> extractLinks(Document doc) {
+        Set<String> ordered = new LinkedHashSet<>();
+        for (Element link : doc.select("a[href]")) {
+            String href = link.attr("href").trim();
+            if (href.isEmpty()) {
+                continue;
+            }
+            String absolute = link.attr("abs:href");
+            if (absolute == null || absolute.isBlank()) {
+                absolute = href;
+            }
+            if (absolute.startsWith("#")) {
+                continue;
+            }
+            ordered.add(absolute);
+        }
+        return new ArrayList<>(ordered);
     }
 
     private Element selectMain(Document doc) {

--- a/src/main/java/scrapping/noti_radar/service/NotificationService.java
+++ b/src/main/java/scrapping/noti_radar/service/NotificationService.java
@@ -34,7 +34,7 @@ public class NotificationService {
             this.sendGridApiKey = sendGridApiKey;
         }
 
-        public void sendChangeEmail(String url, String summary) {
+        public void sendChangeEmail(String monitoredUrl, String changeUrl, String summary) {
             /*SimpleMailMessage msg = new SimpleMailMessage();
             msg.setFrom(props.getMailFrom());
             //msg.setTo(props.getMailTo());
@@ -42,9 +42,14 @@ public class NotificationService {
             msg.setSubject("[Monitor] Cambio detectado: " + url);
             msg.setText("URL: " + url + "\n\nResumen de cambios:\n" + summary + "\n");
             mailSender.send(msg);*/
-            String subject = "[Monitor] Cambio detectado: " + url;
-            String body = "URL: " + url + "\n\nResumen de cambios:\n" + summary + "\n";
-            sendEmail(subject, body);
+            String subject = "[Monitor] Cambio detectado: " + changeUrl;
+            StringBuilder body = new StringBuilder();
+            body.append("Página monitoreada: ").append(monitoredUrl).append("\n");
+            if (!monitoredUrl.equals(changeUrl)) {
+                body.append("Nuevo enlace: ").append(changeUrl).append("\n");
+            }
+            body.append("\nResumen de cambios:\n").append(summary).append("\n");
+            sendEmail(subject, body.toString());
         }
 
         public void sendTestEmail() {


### PR DESCRIPTION
## Summary
- track the last set of links seen in each monitored page to detect newly published URLs
- update notification emails to highlight the newly detected article link while still referencing the monitored page

## Testing
- mvn -q test *(fails: Unable to resolve Spring Boot parent POM because Maven Central returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e525f5af34832e9a2d787a7c5e8ff8